### PR TITLE
Move to McMaster clu iso Microsoft one

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -1,7 +1,7 @@
 name: .NET Core Build and Publish
 
 env:
-  DOTNET_VERSION: "3.1.101"
+  DOTNET_VERSION: "3.1.401"
   OUTPUT_PATH: ${{ github.workspace }}/artifact/
 
 on:
@@ -15,11 +15,21 @@ jobs:
     env:
       ASSEMBLY_VERSION: 1.0.0.${{ github.run_number }}
       ADR_PROJECT_FILE: "./src/adr/adr-cli.csproj"
-      WINDOWS_RUNTIME: "win7-x64"
-      UBUNTU_RUNTIME: "ubuntu.16.04-x64"
+      # WINDOWS_RUNTIME: "win7-x64"
+      # UBUNTU_RUNTIME: "ubuntu.16.04-x64"
       CONFIGURATION: "Release"
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix: 
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        include:
+          - os: ubuntu-latest
+            runtime: linux-x64
+          - os: macOS-latest
+            runtime: osx-x64
+          - os: windows-latest
+            runtime: win-x64
 
     steps:
     - uses: actions/checkout@v2
@@ -33,18 +43,18 @@ jobs:
       working-directory: ./src
 
     - name: Build
-      run: dotnet build --runtime $WINDOWS_RUNTIME --configuration $CONFIGURATION --no-restore -p:Version=$ASSEMBLY_VERSION
+      run: dotnet build --runtime ${{ matrix.runtime }} --configuration ${{ env.CONFIGURATION }} --no-restore -p:Version=${{ env.ASSEMBLY_VERSION }}
       working-directory: ./src
 
     - name: Test
-      run: dotnet test --runtime $WINDOWS_RUNTIME --no-restore --verbosity normal
+      run: dotnet test --runtime ${{ matrix.runtime }} --no-restore --verbosity normal
       working-directory: ./src
 
-    - name: Publish for Windows-x64 single executable
-      run: dotnet publish $ADR_PROJECT_FILE --runtime $WINDOWS_RUNTIME -c $CONFIGURATION --no-restore --no-build /p:PublishSingleFile=true --output ${{ env.OUTPUT_PATH }}/windows-portable/
+    - name: Publish for ${{ matrix.runtime }} single executable
+      run: dotnet publish ${{ env.ADR_PROJECT_FILE }} --runtime ${{ matrix.runtime }} -c ${{ env.CONFIGURATION }} --no-restore --no-build /p:PublishSingleFile=true --output ${{ env.OUTPUT_PATH }}/${{ matrix.runtime }}-portable/
 
-    - name: Publish for Ubuntu-x64 single executable
-      run: dotnet publish $ADR_PROJECT_FILE --runtime $UBUNTU_RUNTIME -c $CONFIGURATION /p:PublishSingleFile=true --output ${{ env.OUTPUT_PATH }}/ubuntu-portable/
+    # - name: Publish for Ubuntu-x64 single executable
+    #   run: dotnet publish $ADR_PROJECT_FILE --runtime $UBUNTU_RUNTIME -c $CONFIGURATION /p:PublishSingleFile=true --output ${{ env.OUTPUT_PATH }}/ubuntu-portable/
 
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -15,9 +15,8 @@ jobs:
     env:
       ASSEMBLY_VERSION: 1.0.0.${{ github.run_number }}
       ADR_PROJECT_FILE: "./src/adr/adr-cli.csproj"
-      # WINDOWS_RUNTIME: "win7-x64"
-      # UBUNTU_RUNTIME: "ubuntu.16.04-x64"
       CONFIGURATION: "Release"
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
     runs-on: ${{ matrix.os }}
     strategy:
@@ -38,12 +37,8 @@ jobs:
       with:
         dotnet-version: ${{ env.DOTNET_VERSION }}
 
-    - name: Install dependencies
-      run: dotnet restore
-      working-directory: ./src
-
     - name: Build
-      run: dotnet build --runtime ${{ matrix.runtime }} --configuration ${{ env.CONFIGURATION }} --no-restore -p:Version=${{ env.ASSEMBLY_VERSION }}
+      run: dotnet build --runtime ${{ matrix.runtime }} --configuration ${{ env.CONFIGURATION }} --nologo -p:Version=${{ env.ASSEMBLY_VERSION }}
       working-directory: ./src
 
     - name: Test
@@ -52,9 +47,6 @@ jobs:
 
     - name: Publish for ${{ matrix.runtime }} single executable
       run: dotnet publish ${{ env.ADR_PROJECT_FILE }} --runtime ${{ matrix.runtime }} -c ${{ env.CONFIGURATION }} --no-restore --no-build /p:PublishSingleFile=true --output ${{ env.OUTPUT_PATH }}/${{ matrix.runtime }}-portable/
-
-    # - name: Publish for Ubuntu-x64 single executable
-    #   run: dotnet publish $ADR_PROJECT_FILE --runtime $UBUNTU_RUNTIME -c $CONFIGURATION /p:PublishSingleFile=true --output ${{ env.OUTPUT_PATH }}/ubuntu-portable/
 
     - name: Upload a Build Artifact
       uses: actions/upload-artifact@v2

--- a/src/adr.tests/FirstTest.cs
+++ b/src/adr.tests/FirstTest.cs
@@ -14,7 +14,7 @@ namespace adr.tests
         [Fact]
         public void FailingTest()
         {
-            Assert.Equal(5, Add(2, 2));
+            Assert.NotEqual(5, Add(2, 2));
         }
 
         int Add(int x, int y)

--- a/src/adr.tests/tests.csproj
+++ b/src/adr.tests/tests.csproj
@@ -6,8 +6,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.3.0-beta2-build3683" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/adr.tests/tests.csproj
+++ b/src/adr.tests/tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeIdentifiers>win7-x64;ubuntu.16.04-x64</RuntimeIdentifiers>    
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;osx-x64</RuntimeIdentifiers>    
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/adr/Program.cs
+++ b/src/adr/Program.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.CommandLineUtils;
+﻿using McMaster.Extensions.CommandLineUtils;
 
 namespace adr
 {

--- a/src/adr/adr-cli.csproj
+++ b/src/adr/adr-cli.csproj
@@ -6,7 +6,7 @@
     <StartupObject>adr.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 </Project>

--- a/src/adr/adr-cli.csproj
+++ b/src/adr/adr-cli.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <RuntimeIdentifiers>win7-x64;ubuntu.16.04-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64;win-x86;linux-x64;osx-x64</RuntimeIdentifiers>    
     <StartupObject>adr.Program</StartupObject>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
The Package Microsoft.Extensions.CommandLineUtils is no longer supported,
so moving to McMaster.Extensions.CommandLineUtils the unofficial
successor.

Also upgrading some references just to be up to date